### PR TITLE
Update lint rule name & implement rendering mazes as SVGs & more algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ petgraph = "0.5.1"
 
 [dev-dependencies]
 quickcheck = "0.9.1"
+clap = { version = "3.1.5", features = ["derive"] }
+
+[[example]]
+name="mazes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ petgraph = "0.5.1"
 [dev-dependencies]
 quickcheck = "0.9.1"
 clap = { version = "3.1.5", features = ["derive"] }
-
-[[example]]
-name="mazes"

--- a/examples/mazes.rs
+++ b/examples/mazes.rs
@@ -160,7 +160,9 @@ fn main() {
     };
 
     if svgoutput {
-        let svg: String = match maze.to_svg(Some(myoptions)) {
+    if svgoutput {
+        let svg: String = match maze.to_svg(myoptions) { // Use my options
+        //let svg: String = match maze.to_svg(SVGoptions::new()) { // Use default options
             Ok(val) => val,
             Err(_) => "".to_string(),
         };

--- a/examples/mazes.rs
+++ b/examples/mazes.rs
@@ -1,0 +1,169 @@
+//! Maze generator test program
+//!
+use maze_generator::ellers_algorithm::EllersGenerator;
+use maze_generator::growing_tree::GrowingTreeGenerator;
+use maze_generator::prelude::*;
+use maze_generator::prims_algorithm::PrimsGenerator;
+use maze_generator::recursive_backtracking::RbGenerator;
+
+//use std::collections::HashMap;
+use clap::{Arg, Command};
+use std::time::Instant;
+
+//use std::io::{self};
+
+fn main() {
+    // Define the CLI arguments
+    let matches = Command::new("Maze Test Program")
+        .version("0.1.0")
+        .about("Test harness for maze_generator library crate")
+        .arg(
+            Arg::new("type")
+                .short('t')
+                .long("type")
+                .takes_value(true)
+                .default_value("df")
+                .help("A maze generator name (ellers|prims|growingtree). Uses recursive backtracing if not specified."),
+        )
+        .arg(
+            Arg::new("width")
+                .short('w')
+                .long("width")
+                .takes_value(true)
+                .default_value("20")
+                .validator(|s| s.parse::<usize>())
+                .help("Maze width in cells"),
+        )
+        .arg(
+            Arg::new("height")
+                .short('h')
+                .long("height")
+                .takes_value(true)
+                .default_value("20")
+                .validator(|s| s.parse::<usize>())
+                .help("Maze height in cells"),
+        )
+        .arg(
+            Arg::new("method")
+                .short('m')
+                .long("method")
+                .takes_value(true)
+                .default_value("0")
+                .validator(|s| s.parse::<usize>())
+                .help("Selection method"),
+        )
+        .arg(
+            Arg::new("static")
+                .short('s')
+                .long("static")
+                .takes_value(false)
+                .help("Use a static rng seed"),
+        )
+        .arg(
+            Arg::new("textoutput")
+                .short('d')
+                .long("textoutput")
+                .takes_value(false)
+                .help("Output the text/debug version to stdout"),
+        )
+        .arg(
+            Arg::new("svgoutput")
+                .short('v')
+                .long("svgoutput")
+                .takes_value(false)
+                .help("Output the svg version to stdout"),
+        )
+        .get_matches();
+
+    // Process the args
+    let num_str = matches.value_of("width");
+    let width = match num_str {
+        None => 10,
+        Some(s) => match s.parse::<i32>() {
+            Ok(n) => n,
+            Err(_) => 11,
+        },
+    };
+
+    let num_str = matches.value_of("height");
+    let height = match num_str {
+        None => 10,
+        Some(s) => match s.parse::<i32>() {
+            Ok(n) => n,
+            Err(_) => 11,
+        },
+    };
+
+    let num_str = matches.value_of("method");
+    let selectionmethod = match num_str {
+        None => 0,
+        Some(s) => match s.parse::<i32>() {
+            Ok(n) => n,
+            Err(_) => 1,
+        },
+    };
+
+    let mut rngseed = None;
+    let isstatic = matches.is_present("static");
+    //eprintln!("Static {:?}", isstatic);
+    if isstatic {
+        rngseed = Some([42; 32]);
+    }
+
+    let textoutput = matches.is_present("textoutput");
+    let svgoutput = matches.is_present("svgoutput");
+
+    // Generate the maze
+    let start = Instant::now();
+    let gentype = matches.value_of("type").unwrap().to_lowercase();
+    let actualtype: String;
+    let maze = match gentype.as_str() {
+        "ellers" | "eller" => {
+            actualtype = String::from("Eller's");
+            let mut generator = EllersGenerator::new(rngseed);
+            generator.generate(width, height)
+        }
+        "gt" | "growing" | "growingtree" => {
+            actualtype = String::from("Growing tree");
+            let mut generator = GrowingTreeGenerator::new(rngseed);
+            generator.set_selectionmethod(selectionmethod);
+            generator.generate(width, height)
+        }
+        "prim" | "prims" => {
+            actualtype = String::from("Prim's");
+            let mut generator = PrimsGenerator::new(rngseed);
+            generator.generate(width, height)
+        }
+        _ => {
+            // Default to RbGenerator, so no need to specify it
+            actualtype = String::from("Recursive backtracing");
+            let mut generator = RbGenerator::new(rngseed);
+            generator.generate(width, height)
+        }
+    };
+
+    let duration = start.elapsed();
+    eprintln!(
+        "Generate {:?}({}) as static {:?}, Size {} x {} in time {:?}",
+        actualtype, gentype, isstatic, width, height, duration
+    );
+
+    if textoutput {
+        print!("{:?}", maze);
+    }
+
+    // SVG generation options, lurid green lines and a smaller cellsize, use the defaults for everything else
+    let myoptions = SVGoptions {
+        strokecol: String::from("green"),
+        padding: 8,
+        ..Default::default()
+    };
+
+    if svgoutput {
+        let svg: String = match maze.to_svg(Some(myoptions)) {
+            Ok(val) => val,
+            Err(_) => "".to_string(),
+        };
+        println!("{}", svg);
+    }
+}

--- a/examples/mazes.rs
+++ b/examples/mazes.rs
@@ -1,22 +1,19 @@
-//! Maze generator test program
+//! Maze generator example program
 //!
 use maze_generator::ellers_algorithm::EllersGenerator;
-use maze_generator::growing_tree::GrowingTreeGenerator;
+use maze_generator::growing_tree::*;
 use maze_generator::prelude::*;
 use maze_generator::prims_algorithm::PrimsGenerator;
 use maze_generator::recursive_backtracking::RbGenerator;
 
-//use std::collections::HashMap;
 use clap::{Arg, Command};
 use std::time::Instant;
 
-//use std::io::{self};
-
 fn main() {
     // Define the CLI arguments
-    let matches = Command::new("Maze Test Program")
+    let matches = Command::new("Maze Example Program")
         .version("0.1.0")
-        .about("Test harness for maze_generator library crate")
+        .about("Generate mazes from the command line using maze_generator library crate")
         .arg(
             Arg::new("type")
                 .short('t')
@@ -105,7 +102,6 @@ fn main() {
 
     let mut rngseed = None;
     let isstatic = matches.is_present("static");
-    //eprintln!("Static {:?}", isstatic);
     if isstatic {
         rngseed = Some([42; 32]);
     }
@@ -126,7 +122,11 @@ fn main() {
         "gt" | "growing" | "growingtree" => {
             actualtype = String::from("Growing tree");
             let mut generator = GrowingTreeGenerator::new(rngseed);
-            generator.set_selectionmethod(selectionmethod);
+            generator.selectionmethod = match selectionmethod {
+                1 => growing_tree::GrowingTreeSelectionMethod::MostRecent,
+                2 => growing_tree::GrowingTreeSelectionMethod::Random,
+                _ => growing_tree::GrowingTreeSelectionMethod::First,
+            };
             generator.generate(width, height)
         }
         "prim" | "prims" => {
@@ -153,16 +153,15 @@ fn main() {
     }
 
     // SVG generation options, lurid green lines and a smaller cellsize, use the defaults for everything else
-    let myoptions = SVGoptions {
+    let myoptions = SvgOptions {
         strokecol: String::from("green"),
         padding: 8,
+        height: Some(400),
         ..Default::default()
     };
 
     if svgoutput {
-    if svgoutput {
-        let svg: String = match maze.to_svg(myoptions) { // Use my options
-        //let svg: String = match maze.to_svg(SVGoptions::new()) { // Use default options
+        let svg: String = match maze.to_svg(myoptions) {
             Ok(val) => val,
             Err(_) => "".to_string(),
         };

--- a/src/growing_tree.rs
+++ b/src/growing_tree.rs
@@ -1,0 +1,165 @@
+//! Growing tree implementation
+//!
+//! 1. Let C be a list of cells, initially empty. Add one cell to C, at random.
+//! 2. Choose a cell from C, and carve a passage to any unvisited neighbor of
+//!    that cell, adding that neighbor to C as well. If there are no unvisited
+//!    neighbors, remove the cell from C.
+//! 3. Repeat #2 until C is empty
+//!
+//! Pretty straight-forward, really. But the fun lies in how you choose the cells
+//! from C, in step #2. If you always choose the newest cell (the one most
+//! recently added), you’ll get the recursive backtracker. If you always choose a
+//! cell at random, you get Prim’s. It’s remarkably fun to experiment with other
+//! ways to choose cells from C.
+//!
+//! *Explanation and credits to
+//! [Jamis Buck's Buckblog]( http://weblog.jamisbuck.org/2011/1/27/maze-generation-growing-tree-algorithm.html)*
+
+use crate::prelude::*;
+use rand::prelude::*;
+use rand_chacha::ChaChaRng;
+//use std::collections::{HashSet, VecDeque};
+
+/// [`Generator`] implementation which uses the recursive-backtracking algorithm.
+#[derive(Debug, Clone)]
+pub struct GrowingTreeGenerator {
+    rng: ChaChaRng,
+    selectionmethod: i32,
+    cellstack: Vec<Coordinates>,
+    //frontier: Vec<Coordinates>,
+    visited: Vec<Coordinates>,
+    neighbours: Vec<Coordinates>,
+}
+
+impl GrowingTreeGenerator {
+    /// Create a new instance.
+    ///
+    /// Optionally a 32 bit seed can be provided to seed the internal random generator.
+    /// Giving a seed results in identical mazes being generated which omitting it sources the
+    /// random generator from entropy.
+    ///
+    ///
+    pub fn new(seed: Option<[u8; 32]>) -> GrowingTreeGenerator {
+        GrowingTreeGenerator {
+            rng: match seed {
+                None => ChaChaRng::from_entropy(),
+                Some(seed) => ChaChaRng::from_seed(seed),
+            },
+            selectionmethod: 0, // default to First
+            cellstack: Vec::new(),
+            //frontier: Vec::new(),
+            visited: Vec::new(),
+            neighbours: Vec::new(),
+        }
+    }
+
+    /// Set the selection method
+    ///
+    /// # Arguments
+    ///
+    /// * `selectionmethod` the method for choosing the next cell in the stack
+    /// 1 = Most recent, equivalent to Recursive backtracker
+    /// 2 = Random, equivalent to Prim's
+    /// any other value = First. This is the constructor default.
+    ///
+    /// This is a setter method so that all the generator constructors retain the same signature
+    pub fn set_selectionmethod(&mut self, selectionmethod: i32) {
+        self.selectionmethod = selectionmethod;
+    }
+
+    /// Core algorithm implementation
+    ///
+    ///
+    /// Returns coordinates of the goal field
+    fn carve_passages_from(
+        &mut self,
+        maze: &mut Maze,
+        start_coordinates: Coordinates,
+    ) -> Coordinates {
+        let mut current_coordinates = start_coordinates;
+        let mut goal_coordinates = current_coordinates;
+        let mut max_q = 0;
+
+        self.cellstack.clear();
+        self.cellstack.push(current_coordinates);
+        self.visited.push(current_coordinates); // Mark it as visited
+
+        while ! self.cellstack.is_empty() {
+            self.find_unvisited_neighbours(maze, current_coordinates);
+            //eprintln!("Stacks: cellstack {}, neighbours {}, current {:?}", self.cellstack.len(), self.neighbours.len(), current_coordinates);
+
+            if self.neighbours.is_empty()  {
+                // We've reached a dead end - remove the current_coordinates from the stack
+                if self.cellstack.contains(&current_coordinates) {
+                    let idx = self
+                        .cellstack
+                        .iter()
+                        .position(|&r| r == current_coordinates)
+                        .unwrap();
+                    self.cellstack.remove(idx);
+                }
+
+                // If there are no more cells, quit
+                if self.cellstack.is_empty() {
+                    continue;
+                }
+
+                // And now select a new current cell according to 'selectionmethod' parameter
+                // pop and remove wont fail because we just tested for non-zero length
+                current_coordinates = match self.selectionmethod {
+                    1 => self.cellstack.pop().unwrap(), // Most recent, equivalent to Recursive backtracker
+                    2 => self.cellstack[self.rng.gen_range(0, self.cellstack.len())], // Random, equivalent to Prim's
+                    _ => self.cellstack.remove(0),                                    // First
+                };
+            } else {
+                // We have some neighbours so we can make a passage
+
+                // Choose a random neighbouring cell and move to it.
+                let next_coords = self.neighbours[self.rng.gen_range(0, self.neighbours.len())];
+                maze.graph.add_edge(current_coordinates, next_coords, ()); // Knock down the wall between them
+                self.cellstack.push(next_coords);
+                current_coordinates = next_coords;
+                self.visited.push(current_coordinates); // Mark the new cell as visited
+
+                // Keep track of the longest cell stack. Our target is at the end of this stack - the neighbour to which we just connected
+                if self.cellstack.len() > max_q {
+                    max_q = self.cellstack.len();
+                    goal_coordinates = current_coordinates;
+                }
+            }
+        }
+        goal_coordinates
+    }
+
+    // Find the neighbours of this cell that have NOT been visited
+    fn find_unvisited_neighbours(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
+        self.neighbours.clear(); // Clear the current neighbour list
+
+        // Look all around, add any UNvisited neighbours to the list
+        for i_dir in Direction::all().iter() {
+            let next_coords = current_coordinates.next(i_dir);
+            if maze.are_coordinates_inside(&next_coords) && !self.visited.contains(&next_coords) {
+                self.neighbours.push(next_coords);
+            }
+        }
+    }
+}
+
+impl Generator for GrowingTreeGenerator {
+    fn generate(&mut self, width: i32, height: i32) -> Maze {
+        let start = (0, 0).into();
+        let mut maze = Maze::new(width, height, start, (0, 0).into());
+
+        maze.goal = self.carve_passages_from(&mut maze, start);
+
+        maze
+    }
+}
+
+#[cfg(test)]
+mod test {
+    test_all_coordinates_have_fields!(super::GrowingTreeGenerator);
+    test_route_from_start_to_goal_exists!(super::GrowingTreeGenerator);
+    test_all_fields_connected!(super::GrowingTreeGenerator);
+    test_generation_is_deterministic!(super::GrowingTreeGenerator);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(trivial_numeric_casts, trivial_casts, unsafe_code)]
 #![warn(
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,4 +55,6 @@ mod test_util;
 #[macro_use]
 pub mod prelude;
 pub mod ellers_algorithm;
+pub mod growing_tree;
+pub mod prims_algorithm;
 pub mod recursive_backtracking;

--- a/src/prelude/maze.rs
+++ b/src/prelude/maze.rs
@@ -4,6 +4,9 @@ use petgraph::graphmap::GraphMap;
 use petgraph::stable_graph::DefaultIx;
 use petgraph::Undirected;
 
+use std::collections::HashMap;
+use std::fmt::Write;
+
 pub(crate) type MazeGraph = GraphMap<Coordinates, (), Undirected>;
 
 /// A collection of [`Field`]s with passages between them.
@@ -113,6 +116,152 @@ impl std::fmt::Debug for Maze {
         }
 
         Ok(())
+    }
+}
+
+impl Maze {
+    /// Generate an SVG version of the maze
+    pub fn to_svg(&self, options: Option<HashMap<&str, i32>>) -> Result<String, std::fmt::Error> {
+        // Default generation options
+        let mut opthash = HashMap::from([
+            ("padding", 10),
+            ("height", 10 + (self.size.0 + self.size.1) * 10),
+            ("markersize", 2),
+        ]);
+        // Override with supplied options where possible
+        match options {
+            Some(options) => {
+                for (opt, val) in options {
+                    opthash.insert(opt, val);
+                }
+            }
+            None => (),
+        }
+        // Use these options
+        let padding = opthash["padding"]; // Pad the maze all around by this amount.
+        let markersize = opthash["markersize"]; // Size of the Start and Goal markers
+        let mut height = opthash["height"]; // Height and width of the maze image (excluding padding), in pixels
+        let mut width = height * self.size.0 / self.size.1;
+
+        // Scaling factors mapping maze coordinates to image/svg coordinates
+        let scx = width / self.size.0;
+        let scx2 = scx / 2;
+        let scy = height / self.size.1;
+        let scy2 = scy / 2;
+        // Recalculate integer width, height now that we have the actual elements
+        width = scx * self.size.0;
+        height = scy * self.size.1;
+        let mut x1;
+        let mut x2;
+        let mut y1;
+        let mut y2;
+
+        // Write the SVG to the return String
+        let mut svg = String::new();
+        writeln!(svg, "<?xml version=\"1.0\" encoding=\"utf-8\"?>").unwrap();
+        writeln!(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\"").unwrap();
+        writeln!(svg, "    xmlns:xlink=\"http://www.w3.org/1999/xlink\"").unwrap();
+        writeln!(
+            svg,
+            "    width=\"{}\" height=\"{}\" viewBox=\"{} {} {} {}\">",
+            width + 2 * padding,
+            height + 2 * padding,
+            -padding,
+            -padding,
+            width + 2 * padding,
+            height + 2 * padding
+        )
+        .unwrap();
+
+        writeln!(svg, "<defs>\n<style type=\"text/css\"><![CDATA[").unwrap();
+        writeln!(svg, "line {{").unwrap();
+        writeln!(svg, "    stroke: #000000;\n    stroke-linecap: square;").unwrap();
+        writeln!(svg, "    stroke-width: 5;\n}}").unwrap();
+        writeln!(svg, "]]></style>\n</defs>").unwrap();
+
+        for iy in 0..self.size.1 {
+            // print top passage
+            for ix in 0..self.size.0 {
+                if self
+                    .get_field(&(ix, iy).into())
+                    .unwrap()
+                    .has_passage(&Direction::North)
+                {
+                    // Do nothing. This code structure keeps the SVG output aligned with the original text debug output
+                } else {
+                    x1 = ix * scx;
+                    y1 = iy * scy;
+                    x2 = (ix + 1) * scx;
+                    y2 = iy * scy;
+                    writeln!(
+                        svg,
+                        "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"/>",
+                        x1, y1, x2, y2
+                    )
+                    .unwrap();
+                }
+            }
+
+            // print left passage and room markers
+            for ix in 0..self.size.0 {
+                let field = self.get_field(&(ix, iy).into()).unwrap();
+                if field.has_passage(&Direction::West) {
+                    // Do nothing
+                } else {
+                    x1 = ix * scx;
+                    y1 = iy * scy;
+                    x2 = ix * scx;
+                    y2 = (iy + 1) * scy;
+                    writeln!(
+                        svg,
+                        "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"/>",
+                        x1, y1, x2, y2
+                    )
+                    .unwrap();
+                }
+                // Special cells
+                match field.field_type {
+                    FieldType::Start => {
+                        x1 = ix * scx + scx2;
+                        y1 = iy * scy + scy2;
+                        writeln!(svg, "<circle cx=\"{}\" cy=\"{}\" r=\"{}\" stroke=\"red\" stroke-width=\"{}\" fill=\"red\" />", x1, y1, markersize, markersize + 1).unwrap();
+                    }
+                    FieldType::Goal => {
+                        x1 = ix * scx + scx2;
+                        y1 = iy * scy + scy2;
+                        writeln!(svg, "<circle cx=\"{}\" cy=\"{}\" r=\"{}\" stroke=\"blue\" stroke-width=\"{}\" fill=\"blue\" />", x1, y1, markersize, markersize + 1).unwrap();
+                    }
+                    _ => continue,
+                };
+            }
+
+            // print bottom border line
+            x1 = 0;
+            y1 = (self.size.1) * scy;
+            x2 = (self.size.0) * scx;
+            y2 = (self.size.1) * scy;
+            writeln!(
+                svg,
+                "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"/>",
+                x1, y1, x2, y2
+            )
+            .unwrap();
+
+            // print right border line
+            x1 = (self.size.0) * scx;
+            y1 = 0;
+            x2 = (self.size.0) * scx;
+            y2 = (self.size.1) * scy;
+            writeln!(
+                svg,
+                "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"/>",
+                x1, y1, x2, y2
+            )
+            .unwrap();
+        }
+        writeln!(svg, "</svg>").unwrap();
+
+        Ok(svg)
     }
 }
 

--- a/src/prelude/maze.rs
+++ b/src/prelude/maze.rs
@@ -120,21 +120,15 @@ impl std::fmt::Debug for Maze {
 
 impl Maze {
     /// Generate an SVG version of the maze, returned as a String which you can then write to a file...or whatever
-    pub fn to_svg(&self, options: Option<SVGoptions>) -> Result<String, std::fmt::Error> {
-        // Generation options or  defaults
-        let svgoptions: SVGoptions = match options {
-            Some(opt) => opt,
-            None => SVGoptions::new(),
-        };
-        // Use these options
-        let padding = svgoptions.padding; // Pad the maze all around by this amount.
-                                          //let strokewidth = svgoptions.strokewidth; // Thikness of lines
+    pub fn to_svg(&self, svgoptions:SVGoptions) -> Result<String, std::fmt::Error> {
+        // Get the options for convenience
+        let padding = svgoptions.padding; // Maze cell size - also padding around 
         let markersize = svgoptions.markersize; // Size of the Start and Goal markers
-        let mut height = svgoptions.height; // Height and width of the maze image (excluding padding), in pixels
+        let mut height = svgoptions.height; // Height of the maze image (excluding padding), in pixels
         if height == 0 {
-            height = padding + (self.size.0 + self.size.1) * padding;
+            height = (2 + self.size.1) * padding;
         }
-        let mut width = height * self.size.0 / self.size.1;
+        let mut width = height * self.size.0 / self.size.1; // Derive width based on height
 
         // Scaling factors mapping maze coordinates to image/svg coordinates
         let scx = width / self.size.0;

--- a/src/prelude/maze.rs
+++ b/src/prelude/maze.rs
@@ -119,15 +119,16 @@ impl std::fmt::Debug for Maze {
 }
 
 impl Maze {
-    /// Generate an SVG version of the maze, returned as a String which you can then write to a file...or whatever
-    pub fn to_svg(&self, svgoptions:SVGoptions) -> Result<String, std::fmt::Error> {
+    /// Generate an SVG version of the maze, returned as a String which you can then write to a file or use directly
+    pub fn to_svg(&self, svgoptions: SvgOptions) -> Result<String, std::fmt::Error> {
         // Get the options for convenience
-        let padding = svgoptions.padding; // Maze cell size - also padding around 
+        let padding = svgoptions.padding; // Pad the maze all around by this amount.
         let markersize = svgoptions.markersize; // Size of the Start and Goal markers
-        let mut height = svgoptions.height; // Height of the maze image (excluding padding), in pixels
-        if height == 0 {
-            height = (2 + self.size.1) * padding;
-        }
+        let mut height = match svgoptions.height {
+            // Height and width of the maze image (excluding padding), in pixels
+            None => (2 + self.size.1) * padding,
+            Some(h) => h,
+        };
         let mut width = height * self.size.0 / self.size.1; // Derive width based on height
 
         // Scaling factors mapping maze coordinates to image/svg coordinates

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -4,11 +4,13 @@ mod coordinates;
 mod direction;
 mod field;
 mod maze;
+mod svgoptions;
 
 pub use coordinates::*;
 pub use direction::*;
 pub use field::*;
 pub use maze::*;
+pub use svgoptions::*;
 
 /// Generic generator Api implemented by all algorithms to generate a maze
 pub trait Generator {

--- a/src/prelude/svgoptions.rs
+++ b/src/prelude/svgoptions.rs
@@ -1,0 +1,42 @@
+use crate::prelude::*;
+use std::fmt::{Debug, Display, Formatter};
+
+/// Otions for enerating SVG output
+#[derive(Debug)]
+pub struct SVGoptions {
+    /// Padding, default: 10
+    pub padding: i32,
+    /// Height in pixels - use zero to derive a height based on the padding
+    pub height: i32,
+    /// Marker size - start and end, default: 2
+    pub markersize: i32,
+    /// Start marker colour - either a named colour like 'red' or a hex string like '#FF0000', default: "red"
+    pub startcol: String,
+    /// Goal marker colour, default: "blue"
+    pub goalcol: String,
+    /// Stroke width, default: 4
+    pub strokewidth: i32,
+    /// Stroke  colour, default: "#000000" (black)
+    pub strokecol: String,
+}
+
+impl SVGoptions {
+    /// Create a new instance from the specified coordinate components
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl Default for SVGoptions {
+    fn default() -> Self {
+        SVGoptions {
+            height: 0,
+            padding: 10,
+            markersize: 2,
+            startcol: String::from("red"),
+            goalcol: String::from("blue"),
+            strokewidth: 4,
+            strokecol: String::from("#000000"),
+        }
+    }
+}

--- a/src/prelude/svgoptions.rs
+++ b/src/prelude/svgoptions.rs
@@ -1,13 +1,10 @@
-use crate::prelude::*;
-use std::fmt::{Debug, Display, Formatter};
-
-/// Otions for enerating SVG output
+/// Options for generating SVG output
 #[derive(Debug)]
-pub struct SVGoptions {
+pub struct SvgOptions {
     /// Padding, default: 10
     pub padding: i32,
-    /// Height in pixels - use zero to derive a height based on the padding
-    pub height: i32,
+    /// Height in pixels - use None to derive a height based on the padding and number of cells in the maze
+    pub height: Option<i32>,
     /// Marker size - start and end, default: 2
     pub markersize: i32,
     /// Start marker colour - either a named colour like 'red' or a hex string like '#FF0000', default: "red"
@@ -20,17 +17,17 @@ pub struct SVGoptions {
     pub strokecol: String,
 }
 
-impl SVGoptions {
-    /// Create a new instance from the specified coordinate components
+impl SvgOptions {
+    /// Create a default SvgOptions object
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-impl Default for SVGoptions {
+impl Default for SvgOptions {
     fn default() -> Self {
-        SVGoptions {
-            height: 0,
+        SvgOptions {
+            height: None,
             padding: 10,
             markersize: 2,
             startcol: String::from("red"),

--- a/src/prims_algorithm.rs
+++ b/src/prims_algorithm.rs
@@ -1,0 +1,164 @@
+//! Prim's algorithm implementation
+//!
+//! Prim’s approaches the problem from a different angle. Rather than working
+//! edgewise across the entire graph, it starts at one point, and grows outward
+//! from that point. The standard version of the algorithm works something like
+//! this:
+//!
+//! 1. Choose an arbitrary vertex from G (the graph), and add it to some (initially empty) set V.
+//! 2. Choose the edge with the smallest weight from G, that connects a vertex in V with another vertex not in V.
+//! 3. Add that edge to the minimal spanning tree, and the edge’s other vertex to V.
+//! 4. Repeat steps 2 and 3 until V includes every vertex in G.
+//!
+//! And the result is a minimal spanning tree of G. Straightforward enough!
+//! With one little change, it becomes a suitable method for generating mazes:
+//! just change step 2 so that instead of selecting the edge with the smallest
+//! weight, you select an edge at random, as long as it bridges the so-called
+//! “frontier” of the maze (the set of edges that move from within the maze, to
+//! a cell that is outside the maze).
+//!
+//! *Explanation and credits to
+//! [Jamis Buck's Buckblog](http://weblog.jamisbuck.org/2011/1/10/maze-generation-prim-s-algorithm.html)*
+
+use crate::prelude::*;
+use rand::prelude::*;
+use rand_chacha::ChaChaRng;
+use std::collections::{HashSet, VecDeque};
+
+/// [`Generator`] implementation which uses the recursive-backtracking algorithm.
+#[derive(Debug, Clone)]
+pub struct PrimsGenerator {
+    rng: ChaChaRng,
+    frontier: Vec<Coordinates>,
+    visited: Vec<Coordinates>,
+    neighbours: Vec<Coordinates>,
+}
+
+impl PrimsGenerator {
+    /// Create a new instance.
+    ///
+    /// Optionally a 32 bit seed can be provided to seed the internal random generator.
+    /// Giving a seed results in identical mazes being generated which omitting it sources the
+    /// random generator from entropy.
+    pub fn new(seed: Option<[u8; 32]>) -> PrimsGenerator {
+        PrimsGenerator {
+            rng: match seed {
+                None => ChaChaRng::from_entropy(),
+                Some(seed) => ChaChaRng::from_seed(seed),
+            },
+            frontier: Vec::new(),
+            visited: Vec::new(),
+            neighbours: Vec::new(),
+        }
+    }
+
+    /// Core algorithm implementation
+    ///
+    /// Carves passages in all directions in random order from the current coordinates but only
+    /// if the field in that direction has not yet been processed.
+    ///
+    /// Returns coordinates of the goal field
+    fn carve_passages_from(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
+        // Mark our starting cell as 'in' and find its frontier
+        self.markcell(maze, current_coordinates);
+
+        while ! self.frontier.is_empty() {
+            // Choose a random frontier cell
+            let next_coords = self.frontier[self.rng.gen_range(0, self.frontier.len())];
+
+            // Choose a random 'in' neighbour of that cell
+            self.find_visited_neighbours(maze, next_coords);
+            if ! self.neighbours.is_empty() {
+                let ncell = self.neighbours[self.rng.gen_range(0, self.neighbours.len())]; // neighbours is  aways non-zero length
+                maze.graph.add_edge(next_coords, ncell, ()); // Knock down the wall between them
+                self.markcell(maze, next_coords); // frontier cell is now 'in'
+            } else {
+                // No neighbours - panic
+                self.frontier.clear(); // Will cause a non-panic return but the maze will be incomplete
+                eprintln!("No neighbours! {:?}", next_coords);
+            }
+        }
+    }
+
+    // Mark a cell as visited and it's unvisited neighbours as frontier cells
+    fn markcell(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
+        // Mark the current cell as visited
+        if !self.visited.contains(&current_coordinates) {
+            self.visited.push(current_coordinates);
+        }
+
+        // Mark the current cell as not part of the frontier
+        if self.frontier.contains(&current_coordinates) {
+            let idx = self
+                .frontier
+                .iter()
+                .position(|&r| r == current_coordinates)
+                .unwrap();
+            self.frontier.remove(idx);
+        }
+
+        // Add any unvisited neighbours to the frontier
+        for i_dir in Direction::all().iter() {
+            let next_coords = current_coordinates.next(i_dir);
+            if maze.are_coordinates_inside(&next_coords)
+                && !self.frontier.contains(&next_coords)
+                && !self.visited.contains(&next_coords)
+            {
+                self.frontier.push(next_coords);
+            }
+        }
+    }
+
+    // Find the neighbours of this cell that have been visited
+    fn find_visited_neighbours(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
+        self.neighbours.clear(); // Clear the current neighbour list
+
+        // Look all around, add any visited neighbours to the list
+        for i_dir in Direction::all().iter() {
+            let next_coords = current_coordinates.next(i_dir);
+            if maze.are_coordinates_inside(&next_coords) && self.visited.contains(&next_coords) {
+                self.neighbours.push(next_coords);
+            }
+        }
+    }
+
+    // do breadth-first search for the field which has the most distance
+    // Cloned from ellers_algorithm, but passing in maze rather than using the self.graph element (which we don't have here)
+    fn find_suitable_goal(&self, maze: &mut Maze, start: Coordinates) -> Coordinates {
+        let mut already_visited = HashSet::new();
+        let mut queue: VecDeque<Coordinates> = maze.graph.neighbors(start).collect();
+        let mut last_coords = start;
+
+        while let Some(i_coords) = queue.pop_front() {
+            queue.extend(
+                maze.graph
+                    .neighbors(i_coords)
+                    .filter(|c| !already_visited.contains(c)),
+            );
+            already_visited.insert(i_coords);
+            last_coords = i_coords;
+        }
+
+        last_coords
+    }
+}
+
+impl Generator for PrimsGenerator {
+    fn generate(&mut self, width: i32, height: i32) -> Maze {
+        let start = (0, 0).into();
+        let mut maze = Maze::new(width, height, start, (0, 0).into());
+
+        self.carve_passages_from(&mut maze, start);
+        maze.goal = self.find_suitable_goal(&mut maze, start);
+
+        maze
+    }
+}
+
+#[cfg(test)]
+mod test {
+    test_all_coordinates_have_fields!(super::PrimsGenerator);
+    test_route_from_start_to_goal_exists!(super::PrimsGenerator);
+    test_all_fields_connected!(super::PrimsGenerator);
+    test_generation_is_deterministic!(super::PrimsGenerator);
+}

--- a/src/prims_algorithm.rs
+++ b/src/prims_algorithm.rs
@@ -60,18 +60,18 @@ impl PrimsGenerator {
     /// Returns coordinates of the goal field
     fn carve_passages_from(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
         // Mark our starting cell as 'in' and find its frontier
-        self.markcell(maze, current_coordinates);
+        self.mark_cell(maze, current_coordinates);
 
-        while ! self.frontier.is_empty() {
+        while !self.frontier.is_empty() {
             // Choose a random frontier cell
             let next_coords = self.frontier[self.rng.gen_range(0, self.frontier.len())];
 
             // Choose a random 'in' neighbour of that cell
             self.find_visited_neighbours(maze, next_coords);
-            if ! self.neighbours.is_empty() {
+            if !self.neighbours.is_empty() {
                 let ncell = self.neighbours[self.rng.gen_range(0, self.neighbours.len())]; // neighbours is  aways non-zero length
                 maze.graph.add_edge(next_coords, ncell, ()); // Knock down the wall between them
-                self.markcell(maze, next_coords); // frontier cell is now 'in'
+                self.mark_cell(maze, next_coords); // frontier cell is now 'in'
             } else {
                 // No neighbours - panic
                 self.frontier.clear(); // Will cause a non-panic return but the maze will be incomplete
@@ -80,8 +80,8 @@ impl PrimsGenerator {
         }
     }
 
-    // Mark a cell as visited and it's unvisited neighbours as frontier cells
-    fn markcell(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
+    /// Mark a cell as visited and it's unvisited neighbours as frontier cells
+    fn mark_cell(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
         // Mark the current cell as visited
         if !self.visited.contains(&current_coordinates) {
             self.visited.push(current_coordinates);
@@ -109,7 +109,7 @@ impl PrimsGenerator {
         }
     }
 
-    // Find the neighbours of this cell that have been visited
+    /// Find the neighbours of this cell that have been visited
     fn find_visited_neighbours(&mut self, maze: &mut Maze, current_coordinates: Coordinates) {
         self.neighbours.clear(); // Clear the current neighbour list
 
@@ -122,7 +122,7 @@ impl PrimsGenerator {
         }
     }
 
-    // do breadth-first search for the field which has the most distance
+    /// Do breadth-first search for the field which has the most distance
     // Cloned from ellers_algorithm, but passing in maze rather than using the self.graph element (which we don't have here)
     fn find_suitable_goal(&self, maze: &mut Maze, start: Coordinates) -> Coordinates {
         let mut already_visited = HashSet::new();

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -76,6 +76,10 @@ pub(crate) fn test_route_from_start_to_goal_exists(
             let start = maze.start.clone();
             let goal = maze.goal.clone();
 
+            if start == goal && width == 1 && height == 1 {
+                return TestResult::passed(); // degenerate example: single cell maze
+            }
+
             if start == goal {
                 return TestResult::failed();
             }


### PR DESCRIPTION
Running cargo test generated this warning:
```
 --> D:\Data\Dev\rust\projects\maze_generator\src\lib.rs:3:5
  |
3 |     missing_crate_level_docs,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::missing_crate_level_docs`
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default
```